### PR TITLE
Minor mod

### DIFF
--- a/pilotpress.php
+++ b/pilotpress.php
@@ -685,9 +685,9 @@ Copyright: 2013, Ontraport
 	
 		/* please load scripts here vs. printing. it's so much healthier */
 		function load_scripts() {
+			wp_enqueue_script("jquery");
 			wp_register_script("mr_tracking", self::$url_tjs);
 			wp_enqueue_script("mr_tracking");
-			wp_enqueue_script("jquery");
 		}
 
 		function stylesheets() {


### PR DESCRIPTION
Simply switching the order that WordPress loads scripts so that jQuery is first. This helps prevent conflict issues with other plugins and our forms.
